### PR TITLE
User feedback on book shelf updating

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -167,12 +167,27 @@ body, .app {
   cursor: pointer;
 }
 
+.book-shelf-changer.disabled {
+  opacity: 0.9;
+  background-image: none;
+}
+
 /* book cover */
 
 .book-cover {
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
   background: #eee;
 }
+.book-cover .updating {
+  background-color: rgba(0,0,0,0.8);
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  color: white;
+  font-size: 12px;
+  padding-top: 25%;
+}
+
 .book-cover-title {
   padding: 20px 10px 0;
   text-align: center;

--- a/src/components/common/book/BookCover.js
+++ b/src/components/common/book/BookCover.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 
 /** React stateless functional component that represents a book cover. */
-const BookCover = ({ imageWidth, imageHeight, imageURL }) => {
+const BookCover = ({ imageWidth, imageHeight, imageURL, updating }) => {
   return (
     <div className="book-cover"
       style={{
@@ -10,12 +10,14 @@ const BookCover = ({ imageWidth, imageHeight, imageURL }) => {
         height: imageHeight,
         backgroundImage: `url("${imageURL}")`
       }}>
+      {updating && <div className="updating">Updating...</div>}
     </div>
   )
 };
 
 /** PropTypes */
 BookCover.propTypes = {
+  updating: PropTypes.bool,
   imageURL: PropTypes.string,
   imageWidth: PropTypes.number,
   imageHeight: PropTypes.number,
@@ -23,6 +25,7 @@ BookCover.propTypes = {
 
 /** Default values */
 BookCover.defaultProps = {
+  updating: false,
   imageURL: '/assets/default-bookcover-thumb.jpg',
   imageWidth: 128,
   imageHeight: 193

--- a/src/components/common/book/BookShelfPicker.js
+++ b/src/components/common/book/BookShelfPicker.js
@@ -51,11 +51,18 @@ class BookShelfPicker extends React.Component {
   * @description render hook.
   */
   render() {
+
+    // Disable select on shelf updating
+    const selectProps = this.props.updating ? { disabled: 'disabled' } : {};
+    // Disabled styling
+    const divClassName = `book-shelf-changer ${this.props.updating ? "disabled":""}`;
+    
     return (
-      <div className="book-shelf-changer">
+      <div className={divClassName}>
 
         {/* Shelves select */}
         <select
+          {...selectProps}
           ref="select"
           onChange={this.onShelfChange}
           value={this.state.currentShelf}>
@@ -78,6 +85,7 @@ class BookShelfPicker extends React.Component {
 
 /** PropTypes */
 BookShelfPicker.propTypes = {
+  updating: PropTypes.bool,
   currentShelf: PropTypes.string.isRequired,
   shelves: PropTypes.arrayOf(
       PropTypes.shape({
@@ -90,6 +98,7 @@ BookShelfPicker.propTypes = {
 
 /** Default values */
 BookShelfPicker.defaultProps = {
+  updating: false,
   showNone: true
 };
 

--- a/src/components/home/HomePage.js
+++ b/src/components/home/HomePage.js
@@ -14,7 +14,7 @@ class HomePage extends React.Component {
 
   shelfPickerValues = [
       ...VALID_BOOKSHELVES,
-      { id: 'none', name: 'none' }
+      { id: 'none', name: 'None' }
     ];
 
   /**

--- a/src/components/search/SearchPage.js
+++ b/src/components/search/SearchPage.js
@@ -67,7 +67,7 @@ class SearchPage extends React.Component {
         // If we have results, we match the results set
         // with the information about the shelves they belong to,
         // so that the search page is consistent with the home page
-        this.setState({
+        this.refs.root && this.setState({
           books: books.map(
             book => Object.assign({}, book, { shelf: this.props.bookShelfMappings[book.id] || 'none' })
           )
@@ -105,7 +105,7 @@ class SearchPage extends React.Component {
   render() {
 
     return (
-      <div className="search-books">
+      <div ref="root" className="search-books">
         <div className="search-books-bar">
 
           {/* Navigate back to home page */}


### PR DESCRIPTION
When the user changes the shelf for a specific book, the application waits for the BookAPI call to return successfully before updating the local book state and reflect the new shelf. 
During this time:
- the selector is disabled
- the selector has a different styling to express the disabled state
- the book cover shows a transparent black overlay with the "Updating..." label